### PR TITLE
fix: filter multiple not array when init

### DIFF
--- a/packages/src/table-params-store/index.ts
+++ b/packages/src/table-params-store/index.ts
@@ -115,6 +115,7 @@ export class TableParamsStore {
         // eslint-disable-next-line @typescript-eslint/ban-ts-comment
         // @ts-ignore
         column.filterOptionValues = [value]
+        value = [value]
       }
     } else {
       // eslint-disable-next-line @typescript-eslint/ban-ts-comment


### PR DESCRIPTION
# Fix
- 修复当 `syncRouteFilter` `rule.type` 是 `array` 是初始化返回非 `array` 问题